### PR TITLE
Update template creation

### DIFF
--- a/src/kernelsearch/search.py
+++ b/src/kernelsearch/search.py
@@ -211,11 +211,10 @@ def _make_transit_templates(mid_times: np.ndarray,
         # Compute the weights across the smoothing window.
         if smooth_weights == 'uniform':
             weights = np.ones_like(dt)
-        elif smooth_weights == 'tricube':
+
+        if smooth_weights == 'tricube':
             radius = smooth_window/2
             weights = np.where(np.abs(dt) < radius, (1 - np.abs(dt/radius)**3)**3, 0)
-        else:
-            raise ValueError(f"Invalid value '{smooth_weights}' for parameter 'smooth_weights'.")
 
         # Normalize the weights.
         weights = weights/np.sum(weights)

--- a/src/kernelsearch/search.py
+++ b/src/kernelsearch/search.py
@@ -291,6 +291,10 @@ def make_template_grid(periods: np.ndarray,
         errmsg = f"Parameter smooth_window can not be None for WLS search."
         raise ValueError(errmsg)
 
+    if smooth_weights not in ['uniform', 'tricube']:
+        errmsg = f"Invalid value '{smooth_weights}' for parameter smooth_weights."
+        raise ValueError(errmsg)
+
     if search_mode == 'WLS' and smooth_window/np.amin(periods) > 0.5:  # TODO improve on this.
         print("Warning: Cannot make WLS templates at short periods, defaulting to TLS templates.")
         search_mode = 'TLS'
@@ -617,6 +621,10 @@ def template_lstsq(time: np.ndarray,
 
     if normalisation not in ['normal', 'dec_minus_inc']:
         errmsg = f"Invalid value '{normalisation}' for parameter normalisation."
+        raise ValueError(errmsg)
+
+    if smooth_weights not in ['uniform', 'tricube']:
+        errmsg = f"Invalid value '{smooth_weights}' for parameter smooth_weights."
         raise ValueError(errmsg)
 
     # Make sure period grid is sorted.


### PR DESCRIPTION
Refactor of template creation and update for efficiency.
- Merges _make_kernel and _make_smooth_kernel into _make_transit_templates.
- Removes inner from warped templates.
- Change transit model to not return orbit by default (reduced computational load).
- Scale the transit templates by the ref_depth so returned depths are absolute instead of relative to ref_depth.