### PR TITLE
Add short periods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kernelsearch"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     { name = "Geert Jan Talens", email = "phys2523@ox.ac.uk" },
     ]

--- a/src/kernelsearch/search.py
+++ b/src/kernelsearch/search.py
@@ -126,7 +126,11 @@ def _duration_grid(min_duration: float,
         # Increment by fractions of the previous transits ingress/egress.
         duration_step = (duration - full) / oversampling
         duration = duration + duration_step
-        duration_grid.append(duration)
+
+        if duration < max_duration:
+            duration_grid.append(duration)
+        else:
+            duration_grid.append(max_duration)
 
     duration_grid = np.array(duration_grid)
 

--- a/src/kernelsearch/search.py
+++ b/src/kernelsearch/search.py
@@ -685,13 +685,6 @@ def template_lstsq(time: np.ndarray,
     # Make sure period grid is sorted.
     periods = np.sort(periods)
 
-    # Discard short periods when using smoothed kernels.
-    # Computing smoothed kernels is hard when P ~ smooth_window.
-    if search_mode == 'WLS':
-        print(f"Warning: discarding periods less than 2 times the smoothing window for WLS search: P < {2*smooth_window} days.")
-        mask = periods >= 2 * smooth_window
-        periods = periods[mask]
-
     # Pre-compute some arrays.
     result = _prepare_lightcurve(flux, flux_err)
     weights_norm, delta_flux_weighted, weights_sum, flux_mean, chisq0 = result


### PR DESCRIPTION
Adds detailed functionality on how to treat the shortest periods when using WLS mode.
- Don't search short periods.
- Use TLS templates instead of WLS templates.
- Use full WLS templates (very slow).