### PR TITLE
Add a limit to the maximum stable eccentricity

### DIFF
--- a/src/umbra/grid.py
+++ b/src/umbra/grid.py
@@ -317,6 +317,8 @@ def get_transit_duration_limits(period_grid: np.ndarray,
                                 impact_param_bounds: tuple[float, float] = (0.0, 0.9),
                                 min_separation: float = 3.,
                                 circular_orbits: bool = False,
+                                max_eccentricity: Optional[float] = None,
+                                frac_eccentricity: Optional[float] = None
                                 ) -> tuple[DurationLimits, StableOrbit, StableOrbit]:
     """ Compute the minimum and maximum transit duration as a function of the
         orbital period, given possible bounds on the stellar density and
@@ -392,6 +394,14 @@ def get_transit_duration_limits(period_grid: np.ndarray,
         outer_orbit = outer_orbit._replace(ecc=np.zeros_like(period_grid))
         inner_orbit = inner_orbit._replace(ecc=np.zeros_like(period_grid))
 
+    if max_eccentricity is not None:
+        outer_orbit = outer_orbit._replace(ecc=np.minimum(outer_orbit.ecc, max_eccentricity))
+        inner_orbit = inner_orbit._replace(ecc=np.minimum(inner_orbit.ecc, max_eccentricity))
+
+    if frac_eccentricity is not None:
+        outer_orbit = outer_orbit._replace(ecc=frac_eccentricity * outer_orbit.ecc)
+        inner_orbit = inner_orbit._replace(ecc=frac_eccentricity * inner_orbit.ecc)
+
     # Compute the duration limits for the given parameter bounds.
     duration_short = models.get_transit_duration(period_grid, outer_orbit.sm_axis, min_radius_ratio, max_impact_param, outer_orbit.ecc, 90.)
     duration_long = models.get_transit_duration(period_grid, inner_orbit.sm_axis, max_radius_ratio, min_impact_param, inner_orbit.ecc, 270.)
@@ -424,7 +434,7 @@ def get_transit_duration_grid(min_duration: float,
 
     """
 
-    utils._verify_duration_grid_params(True, frac_duration_step)
+    utils._verify_duration_grid_params(True, frac_duration_step, None, None)
 
     if max_duration < min_duration:
         msg = f"The maximum duration is less than the minimum duration, please fix your inputs."

--- a/src/umbra/grid.py
+++ b/src/umbra/grid.py
@@ -230,7 +230,9 @@ DurationLimits = namedtuple('duration_limits', ['short', 'long'])
 
 
 def get_stable_orbits(sm_axis: np.ndarray,
-                      min_separation: float = 3.
+                      min_separation: float = 3.,
+                      circular_orbits: bool = False,
+                      frac_eccentricity: float = 0.95
                       ) -> StableOrbit:
     """ Compute the limiting values for the semi-major axis and eccentricty
         that still result in stable orbits.
@@ -243,6 +245,13 @@ def get_stable_orbits(sm_axis: np.ndarray,
         The minimum orbital separation between the host star and the planet in
         stellar radii. Orbits are stable if the separation at closest approach
         is greater than this value (default: 3).
+    circular_orbits: bool
+        If True compute the shortest and longest duration on circular orbits,
+        i.e. forces the eccentricty to zero (default: False).
+    frac_eccentricity: float
+        The fraction of the maximum stable eccentricity to consider, slightly
+        limits the size of the duration space searched when circular_orbits =
+        False (default: 0.95).
 
     Returns
     -------
@@ -253,6 +262,7 @@ def get_stable_orbits(sm_axis: np.ndarray,
     """
 
     utils._verify_min_separation(min_separation)
+    utils._verify_duration_lims_params(circular_orbits, frac_eccentricity)
 
     # Not all densities produce stable orbits at low periods.
     sm_axis_stable = np.maximum(sm_axis, min_separation)
@@ -260,6 +270,11 @@ def get_stable_orbits(sm_axis: np.ndarray,
     # Not all eccentricties produce stable orbits.
     # Stable orbits asymptotically approach ecc -> 1 as a/R -> inf.
     ecc_stable = (sm_axis_stable - min_separation)/sm_axis_stable
+
+    if circular_orbits:
+        ecc_stable = np.zeros_like(ecc_stable)
+    else:
+        ecc_stable = frac_eccentricity * ecc_stable
 
     stable_orbit = StableOrbit(sm_axis=sm_axis_stable, ecc=ecc_stable)
 
@@ -269,7 +284,9 @@ def get_stable_orbits(sm_axis: np.ndarray,
 def get_orbit_bounds(period_grid: np.ndarray,
                      min_stellar_density: float,
                      max_stellar_density: float,
-                     min_separation: float = 3.
+                     min_separation: float = 3.,
+                     circular_orbits: bool = False,
+                     frac_eccentricity: float = 0.95
                      ) -> tuple[StableOrbit, StableOrbit]:
     """ Given an array of period values and a stellar density interval, compute
         the bounding semi-major axis and eccentricity values of the inner and
@@ -287,6 +304,13 @@ def get_orbit_bounds(period_grid: np.ndarray,
         The minimum orbital separation between the host star and the planet in
         stellar radii. Orbits are stable if the separation at closest approach
         is greater than this value (default: 3).
+    circular_orbits: bool
+        If True compute the shortest and longest duration on circular orbits,
+        i.e. forces the eccentricty to zero (default: False).
+    frac_eccentricity: float
+        The fraction of the maximum stable eccentricity to consider, slightly
+        limits the size of the duration space searched when circular_orbits =
+        False (default: 0.95).
 
     Returns
     -------
@@ -304,8 +328,15 @@ def get_orbit_bounds(period_grid: np.ndarray,
     sm_axis_outer = models.get_sm_axis_kepler(max_stellar_density, period_grid)
 
     # Check the range of semi-major axes and eccentricties that produce stable orbits.
-    inner_orbit = get_stable_orbits(sm_axis_inner, min_separation=min_separation)
-    outer_orbit = get_stable_orbits(sm_axis_outer, min_separation=min_separation)
+    inner_orbit = get_stable_orbits(sm_axis_inner,
+                                    min_separation=min_separation,
+                                    circular_orbits=circular_orbits,
+                                    frac_eccentricity=frac_eccentricity)
+
+    outer_orbit = get_stable_orbits(sm_axis_outer,
+                                    min_separation=min_separation,
+                                    circular_orbits=circular_orbits,
+                                    frac_eccentricity=frac_eccentricity)
 
     return inner_orbit, outer_orbit
 
@@ -317,8 +348,7 @@ def get_transit_duration_limits(period_grid: np.ndarray,
                                 impact_param_bounds: tuple[float, float] = (0.0, 0.9),
                                 min_separation: float = 3.,
                                 circular_orbits: bool = False,
-                                max_eccentricity: Optional[float] = None,
-                                frac_eccentricity: Optional[float] = None
+                                frac_eccentricity: float = 0.95
                                 ) -> tuple[DurationLimits, StableOrbit, StableOrbit]:
     """ Compute the minimum and maximum transit duration as a function of the
         orbital period, given possible bounds on the stellar density and
@@ -348,6 +378,10 @@ def get_transit_duration_limits(period_grid: np.ndarray,
     circular_orbits: bool
         If True compute the shortest and longest duration on circular orbits,
         i.e. forces the eccentricty to zero (default: False).
+    frac_eccentricity: float
+        The fraction of the maximum stable eccentricity to consider, slightly
+        limits the size of the duration space searched when circular_orbits =
+        False (default: 0.95).
 
     Returns
     -------
@@ -373,7 +407,9 @@ def get_transit_duration_limits(period_grid: np.ndarray,
     period_break = get_min_period(min_stellar_density, min_separation)
 
     if np.any(period_grid < period_min):
-        raise ValueError("The shortest period in period_grid is incompatible with the stellar density bounds, please fix your inputs.")
+        msg = ("The shortest period in period_grid is incompatible with the"
+               " stellar density bounds, please fix your inputs.")
+        raise ValueError(msg)
 
     # The minimum stellar density goes up from Pbreak to Pmin.
     # The corresponding stellar radius should decrease.
@@ -387,24 +423,28 @@ def get_transit_duration_limits(period_grid: np.ndarray,
     max_radius_ratio = max_planet_radius/stellar_radius_mindens
 
     # Compute the scaled semi-major axis and eccentricty limits for the density values.
-    result = get_orbit_bounds(period_grid, min_stellar_density, max_stellar_density, min_separation=min_separation)
+    result = get_orbit_bounds(period_grid,
+                              min_stellar_density,
+                              max_stellar_density,
+                              min_separation=min_separation,
+                              circular_orbits=circular_orbits,
+                              frac_eccentricity=frac_eccentricity)
     inner_orbit, outer_orbit = result
 
-    if circular_orbits:
-        outer_orbit = outer_orbit._replace(ecc=np.zeros_like(period_grid))
-        inner_orbit = inner_orbit._replace(ecc=np.zeros_like(period_grid))
-
-    if max_eccentricity is not None:
-        outer_orbit = outer_orbit._replace(ecc=np.minimum(outer_orbit.ecc, max_eccentricity))
-        inner_orbit = inner_orbit._replace(ecc=np.minimum(inner_orbit.ecc, max_eccentricity))
-
-    if frac_eccentricity is not None:
-        outer_orbit = outer_orbit._replace(ecc=frac_eccentricity * outer_orbit.ecc)
-        inner_orbit = inner_orbit._replace(ecc=frac_eccentricity * inner_orbit.ecc)
-
     # Compute the duration limits for the given parameter bounds.
-    duration_short = models.get_transit_duration(period_grid, outer_orbit.sm_axis, min_radius_ratio, max_impact_param, outer_orbit.ecc, 90.)
-    duration_long = models.get_transit_duration(period_grid, inner_orbit.sm_axis, max_radius_ratio, min_impact_param, inner_orbit.ecc, 270.)
+    duration_short = models.get_transit_duration(period_grid,
+                                                 outer_orbit.sm_axis,
+                                                 min_radius_ratio,
+                                                 max_impact_param,
+                                                 outer_orbit.ecc,
+                                                 90.)
+
+    duration_long = models.get_transit_duration(period_grid,
+                                                inner_orbit.sm_axis,
+                                                max_radius_ratio,
+                                                min_impact_param,
+                                                inner_orbit.ecc,
+                                                270.)
 
     duration_limits = DurationLimits(short=duration_short, long=duration_long)
 
@@ -434,7 +474,7 @@ def get_transit_duration_grid(min_duration: float,
 
     """
 
-    utils._verify_duration_grid_params(True, frac_duration_step, None, None)
+    utils._verify_frac_duration_step(frac_duration_step)
 
     if max_duration < min_duration:
         msg = f"The maximum duration is less than the minimum duration, please fix your inputs."

--- a/src/umbra/search.py
+++ b/src/umbra/search.py
@@ -629,6 +629,8 @@ def _transit_search(time: np.ndarray,
                     min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                     max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                     circular_orbits: bool = True,
+                    max_eccentricity: Optional[float] = None,
+                    frac_eccentricity: Optional[float] = None,
                     frac_duration_step: float = 1.05,
                     period_group_sampling: int = 3,
                     normalisation: utils.Normalisation = 'umbra',
@@ -732,7 +734,7 @@ def _transit_search(time: np.ndarray,
     utils._verify_stellar_params(min_stellar_radius, max_stellar_radius, min_stellar_mass, max_stellar_mass)
     utils._verify_period_grid_params(min_transits, min_separation, period_sampling, min_period, max_period)
     utils._verify_epoch_grid_params(epoch_sampling, min_epoch_step, max_epoch_step)
-    utils._verify_duration_grid_params(circular_orbits, frac_duration_step)
+    utils._verify_duration_grid_params(circular_orbits, frac_duration_step, max_eccentricity, frac_eccentricity)
     utils._verify_period_group_sampling(period_group_sampling)
     utils._verify_normalisation(normalisation)
     ld_pars = utils._verify_ld_params(ld_type, ld_pars)
@@ -771,7 +773,9 @@ def _transit_search(time: np.ndarray,
                                                            stellar_density_bounds,
                                                            stellar_radius_bounds,
                                                            min_separation=min_separation,
-                                                           circular_orbits=False)
+                                                           circular_orbits=False,
+                                                           max_eccentricity=max_eccentricity,
+                                                           frac_eccentricity=frac_eccentricity)
 
     if circular_orbits:
         duration_lims = duration_circ
@@ -987,6 +991,8 @@ class TransitSearch:
                  min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                  max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                  circular_orbits: bool = True,
+                 max_eccentricity: Optional[float] = None,
+                 frac_eccentricity: Optional[float] = None,
                  frac_duration_step: float = 1.05,
                  period_group_sampling: int = 3,
                  normalisation: utils.Normalisation = 'umbra',
@@ -998,7 +1004,7 @@ class TransitSearch:
         # Check the input parameters.
         utils._verify_period_grid_params(min_transits, min_separation, period_sampling, min_period, max_period)
         utils._verify_epoch_grid_params(epoch_sampling, min_epoch_step, max_epoch_step)
-        utils._verify_duration_grid_params(circular_orbits, frac_duration_step)
+        utils._verify_duration_grid_params(circular_orbits, frac_duration_step, max_eccentricity, frac_eccentricity)
         utils._verify_period_group_sampling(period_group_sampling)
         utils._verify_normalisation(normalisation)
         num_processes = utils._verify_num_processes(num_processes)
@@ -1013,6 +1019,8 @@ class TransitSearch:
         self.min_epoch_step = min_epoch_step
         self.max_epoch_step = max_epoch_step
         self.circular_orbits = circular_orbits
+        self.max_eccentricity = max_eccentricity
+        self.frac_eccentricity = frac_eccentricity
         self.frac_duration_step = frac_duration_step
         self.period_group_sampling = period_group_sampling
         self.normalisation = normalisation
@@ -1052,6 +1060,8 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
+                                 max_eccentricity=self.max_eccentricity,
+                                 frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,
                                  normalisation=self.normalisation,
@@ -1094,6 +1104,8 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
+                                 max_eccentricity=self.max_eccentricity,
+                                 frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,
                                  normalisation=self.normalisation,
@@ -1141,6 +1153,8 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
+                                 max_eccentricity=self.max_eccentricity,
+                                 frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,
                                  normalisation=self.normalisation,

--- a/src/umbra/search.py
+++ b/src/umbra/search.py
@@ -629,8 +629,7 @@ def _transit_search(time: np.ndarray,
                     min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                     max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                     circular_orbits: bool = True,
-                    max_eccentricity: Optional[float] = None,
-                    frac_eccentricity: Optional[float] = None,
+                    frac_eccentricity: float = 0.95,
                     frac_duration_step: float = 1.05,
                     period_group_sampling: int = 3,
                     normalisation: utils.Normalisation = 'umbra',
@@ -688,6 +687,10 @@ def _transit_search(time: np.ndarray,
     circular_orbits: bool
         If True, search transit durations appropriate for circular orbits,
         otherwise search a wider range for eccentric orbits (default: True).
+    frac_eccentricity: float
+        The fraction of the maximum stable eccentricity to consider, slightly
+        limits the size of the duration space searched when circular_orbits =
+        False (default: 0.95).
     frac_duration_step: float
         The ratio between consecutive durations in the grid. Equivalent to a
         grid with log-steps of log10(frac_duration_step) (default: 1.05).
@@ -734,7 +737,8 @@ def _transit_search(time: np.ndarray,
     utils._verify_stellar_params(min_stellar_radius, max_stellar_radius, min_stellar_mass, max_stellar_mass)
     utils._verify_period_grid_params(min_transits, min_separation, period_sampling, min_period, max_period)
     utils._verify_epoch_grid_params(epoch_sampling, min_epoch_step, max_epoch_step)
-    utils._verify_duration_grid_params(circular_orbits, frac_duration_step, max_eccentricity, frac_eccentricity)
+    utils._verify_duration_lims_params(circular_orbits, frac_eccentricity)
+    utils._verify_frac_duration_step(frac_duration_step)
     utils._verify_period_group_sampling(period_group_sampling)
     utils._verify_normalisation(normalisation)
     ld_pars = utils._verify_ld_params(ld_type, ld_pars)
@@ -774,7 +778,6 @@ def _transit_search(time: np.ndarray,
                                                            stellar_radius_bounds,
                                                            min_separation=min_separation,
                                                            circular_orbits=False,
-                                                           max_eccentricity=max_eccentricity,
                                                            frac_eccentricity=frac_eccentricity)
 
     if circular_orbits:
@@ -851,7 +854,7 @@ def _transit_search(time: np.ndarray,
                 search_mode_: utils.SearchMode = 'TLS'
                 LOGDEBUG("  Using TLS templates for short periods in WLS search.")
             if short_periods == 'WLS':
-                search_mode_: utils.SearchMode = 'TLS'
+                search_mode_: utils.SearchMode = 'TLS'  # TODO
                 is_short_period = True
                 LOGDEBUG("  Using WLS templates for short periods in WLS search.")
 
@@ -991,8 +994,7 @@ class TransitSearch:
                  min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                  max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                  circular_orbits: bool = True,
-                 max_eccentricity: Optional[float] = None,
-                 frac_eccentricity: Optional[float] = None,
+                 frac_eccentricity: float = 0.95,
                  frac_duration_step: float = 1.05,
                  period_group_sampling: int = 3,
                  normalisation: utils.Normalisation = 'umbra',
@@ -1004,7 +1006,8 @@ class TransitSearch:
         # Check the input parameters.
         utils._verify_period_grid_params(min_transits, min_separation, period_sampling, min_period, max_period)
         utils._verify_epoch_grid_params(epoch_sampling, min_epoch_step, max_epoch_step)
-        utils._verify_duration_grid_params(circular_orbits, frac_duration_step, max_eccentricity, frac_eccentricity)
+        utils._verify_duration_lims_params(circular_orbits, frac_eccentricity)
+        utils._verify_frac_duration_step(frac_duration_step)
         utils._verify_period_group_sampling(period_group_sampling)
         utils._verify_normalisation(normalisation)
         num_processes = utils._verify_num_processes(num_processes)
@@ -1019,7 +1022,6 @@ class TransitSearch:
         self.min_epoch_step = min_epoch_step
         self.max_epoch_step = max_epoch_step
         self.circular_orbits = circular_orbits
-        self.max_eccentricity = max_eccentricity
         self.frac_eccentricity = frac_eccentricity
         self.frac_duration_step = frac_duration_step
         self.period_group_sampling = period_group_sampling
@@ -1060,7 +1062,6 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
-                                 max_eccentricity=self.max_eccentricity,
                                  frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,
@@ -1104,7 +1105,6 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
-                                 max_eccentricity=self.max_eccentricity,
                                  frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,
@@ -1153,7 +1153,6 @@ class TransitSearch:
                                  min_epoch_step=self.min_epoch_step,
                                  max_epoch_step=self.max_epoch_step,
                                  circular_orbits=self.circular_orbits,
-                                 max_eccentricity=self.max_eccentricity,
                                  frac_eccentricity=self.frac_eccentricity,
                                  frac_duration_step=self.frac_duration_step,
                                  period_group_sampling=self.period_group_sampling,

--- a/src/umbra/utils.py
+++ b/src/umbra/utils.py
@@ -233,7 +233,9 @@ def _verify_epoch_grid_params(epoch_sampling: int,
 
 
 def _verify_duration_grid_params(circular_orbits: bool,
-                                 frac_duration_step: float
+                                 frac_duration_step: float,
+                                 max_eccentricity: Optional[float],
+                                 frac_eccentricity: Optional[float]
                                  ):
     """ Check the duration grid parameters are valid.
     """
@@ -244,6 +246,14 @@ def _verify_duration_grid_params(circular_orbits: bool,
 
     if not (1 < frac_duration_step <= 1.5):
         msg = f"Parameter frac_duration_step must be in range (1, 1.5]."
+        raise ValueError(msg)
+
+    if max_eccentricity is not None and not (0 < max_eccentricity <= 1):
+        msg = f"Parameter max_eccentricity must be in range (0, 1]."
+        raise ValueError(msg)
+
+    if frac_eccentricity is not None and not (0 < frac_eccentricity <= 1):
+        msg = f"Parameter frac_eccentricity must be in range (0, 1]."
         raise ValueError(msg)
 
     return

--- a/src/umbra/utils.py
+++ b/src/umbra/utils.py
@@ -232,28 +232,27 @@ def _verify_epoch_grid_params(epoch_sampling: int,
     return
 
 
-def _verify_duration_grid_params(circular_orbits: bool,
-                                 frac_duration_step: float,
-                                 max_eccentricity: Optional[float],
-                                 frac_eccentricity: Optional[float]
-                                 ):
-    """ Check the duration grid parameters are valid.
+def _verify_duration_lims_params(circular_orbits: bool,
+                                 frac_eccentricity: float):
+    """ Check the duration limits parameters are valid.
     """
 
     if not isinstance(circular_orbits, bool):
         msg = f"Parameter circular_orbits must be boolean."
         raise ValueError(msg)
 
+    if not (0 < frac_eccentricity <= 1):
+        msg = f"Parameter frac_eccentricity must be in range (0, 1]."
+        raise ValueError(msg)
+
+    return
+
+def _verify_frac_duration_step(frac_duration_step: float):
+    """ Check the frac_duration_step parameter is valid.
+    """
+
     if not (1 < frac_duration_step <= 1.5):
         msg = f"Parameter frac_duration_step must be in range (1, 1.5]."
-        raise ValueError(msg)
-
-    if max_eccentricity is not None and not (0 < max_eccentricity <= 1):
-        msg = f"Parameter max_eccentricity must be in range (0, 1]."
-        raise ValueError(msg)
-
-    if frac_eccentricity is not None and not (0 < frac_eccentricity <= 1):
-        msg = f"Parameter frac_eccentricity must be in range (0, 1]."
         raise ValueError(msg)
 
     return


### PR DESCRIPTION
This PR adds a fractional limit on the maximum stable eccentricity. This change slightly reduces the transit duration space searched, but improves the time it takes to search significantly.