### PR TITLE
Update names and values

### DIFF
--- a/src/umbra/diagnostics.py
+++ b/src/umbra/diagnostics.py
@@ -102,13 +102,13 @@ def plot_quick_look(time,
                     flux,
                     periodogram,
                     transit_model,
-                    smooth_window=None,
+                    filter_window=None,
                     figure_file=None):
     """ Make a diagnostic plot of the periodogram and phase-folded lightcurve.
     """
 
-    if smooth_window is None:
-        smooth_window = 0
+    if filter_window is None:
+        filter_window = 0
 
     parameters = transit_model['parameters']
     phase = models.phase_fold(time, parameters['period'], parameters['midpoint'])
@@ -137,7 +137,7 @@ def plot_quick_look(time,
     dx = parameters['duration']/parameters['period']
     plt.axvspan(-0.5*dx, 0.5*dx, color='C0', alpha=0.2, zorder=-10)
 
-    dtime = parameters['duration'] + 0.5*smooth_window
+    dtime = parameters['duration'] + 0.5*filter_window
     dx = dtime / parameters['period']
     dx = np.minimum(dx, 0.5)
 
@@ -328,7 +328,7 @@ def plot_2d_periodogram(period_grid,
 
 def plot_oot_baseline(period_grid: np.ndarray,
                       baseline: np.ndarray,
-                      smooth_window: float):
+                      filter_window: float):
     """ Make a figure showing the OoT baseline.
     """
 
@@ -338,10 +338,10 @@ def plot_oot_baseline(period_grid: np.ndarray,
 
     plt.plot(period_grid, baseline)
 
-    plt.axhline(smooth_window, c='k')
+    plt.axhline(filter_window, c='k')
 
-    plt.xlim(period_grid[0], 2 * smooth_window)
-    plt.ylim(0, 2 * smooth_window)
+    plt.xlim(period_grid[0], 2 * filter_window)
+    plt.ylim(0, 2 * filter_window)
 
     plt.xlabel('Period [days]')
     plt.ylabel('OoT Baseline [days]')

--- a/src/umbra/grid.py
+++ b/src/umbra/grid.py
@@ -232,7 +232,7 @@ DurationLimits = namedtuple('duration_limits', ['short', 'long'])
 def get_stable_orbits(sm_axis: np.ndarray,
                       min_separation: float = 3.,
                       circular_orbits: bool = False,
-                      frac_eccentricity: float = 0.95
+                      frac_eccentricity: float = 0.90
                       ) -> StableOrbit:
     """ Compute the limiting values for the semi-major axis and eccentricty
         that still result in stable orbits.
@@ -251,7 +251,7 @@ def get_stable_orbits(sm_axis: np.ndarray,
     frac_eccentricity: float
         The fraction of the maximum stable eccentricity to consider, slightly
         limits the size of the duration space searched when circular_orbits =
-        False (default: 0.95).
+        False (default: 0.90).
 
     Returns
     -------
@@ -286,7 +286,7 @@ def get_orbit_bounds(period_grid: np.ndarray,
                      max_stellar_density: float,
                      min_separation: float = 3.,
                      circular_orbits: bool = False,
-                     frac_eccentricity: float = 0.95
+                     frac_eccentricity: float = 0.90
                      ) -> tuple[StableOrbit, StableOrbit]:
     """ Given an array of period values and a stellar density interval, compute
         the bounding semi-major axis and eccentricity values of the inner and
@@ -310,7 +310,7 @@ def get_orbit_bounds(period_grid: np.ndarray,
     frac_eccentricity: float
         The fraction of the maximum stable eccentricity to consider, slightly
         limits the size of the duration space searched when circular_orbits =
-        False (default: 0.95).
+        False (default: 0.90).
 
     Returns
     -------
@@ -348,7 +348,7 @@ def get_transit_duration_limits(period_grid: np.ndarray,
                                 impact_param_bounds: tuple[float, float] = (0.0, 0.9),
                                 min_separation: float = 3.,
                                 circular_orbits: bool = False,
-                                frac_eccentricity: float = 0.95
+                                frac_eccentricity: float = 0.90
                                 ) -> tuple[DurationLimits, StableOrbit, StableOrbit]:
     """ Compute the minimum and maximum transit duration as a function of the
         orbital period, given possible bounds on the stellar density and
@@ -381,7 +381,7 @@ def get_transit_duration_limits(period_grid: np.ndarray,
     frac_eccentricity: float
         The fraction of the maximum stable eccentricity to consider, slightly
         limits the size of the duration space searched when circular_orbits =
-        False (default: 0.95).
+        False (default: 0.90).
 
     Returns
     -------

--- a/src/umbra/grid.py
+++ b/src/umbra/grid.py
@@ -453,7 +453,7 @@ def get_transit_duration_limits(period_grid: np.ndarray,
 
 def get_transit_duration_grid(min_duration: float,
                               max_duration: float,
-                              frac_duration_step: float = 1.05
+                              frac_duration_step: float = 1.095
                               ) -> np.ndarray:
     """ Compute the duration grid to search.
 
@@ -465,7 +465,7 @@ def get_transit_duration_grid(min_duration: float,
         The maximum transit duration.
     frac_duration_step: float
         The ratio between consecutive durations in the grid. Equivalent to a
-        grid with log-steps of log10(frac_duration_step) (default: 1.05).
+        grid with log-steps of log10(frac_duration_step) (default: 1.095).
 
     Returns
     -------

--- a/src/umbra/models.py
+++ b/src/umbra/models.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Optional, get_args
+from typing import Union, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -409,8 +409,8 @@ def analytic_transit_model(time: np.ndarray,
 
 def _warped_lstsq_init(mid_times: np.ndarray,
                        exp_cadence: float,
-                       smooth_window: float,
-                       smooth_weights: utils.SmoothWeights
+                       filter_window: float,
+                       filter_weights: utils.FilterWeights
                        ) -> tuple[np.ndarray, np.ndarray]:
     """ Prepare the special time and weights arrays for computing WLS templates.
 
@@ -420,11 +420,11 @@ def _warped_lstsq_init(mid_times: np.ndarray,
         The times at which to evaluate the transit model.
     exp_cadence: float
         The exposure cadence of the observations in days.
-    smooth_window: float
-        The smoothing window to use when generating WLS templates, should match
+    filter_window: float
+        The filter window to use when generating WLS templates, should match
         whatever filter was applied to the data.
-    smooth_weights: str
-        The weights to apply across the smoothing window when generating WLS
+    filter_weights: str
+        The weights to apply across the filter window when generating WLS
         templates, should match whatever filter was applied to the data.
 
     Returns
@@ -437,20 +437,20 @@ def _warped_lstsq_init(mid_times: np.ndarray,
 
     """
 
-    # Create the grid of exposures inside the smoothing window.
-    nevals = np.ceil(smooth_window / exp_cadence).astype('int')
+    # Create the grid of exposures inside the filter window.
+    nevals = np.ceil(filter_window / exp_cadence).astype('int')
     if nevals % 2 == 0:
         nevals += 1
 
     mid_idx = nevals // 2
     dt = (np.arange(nevals) - mid_idx) * exp_cadence
 
-    # Compute the weights across the smoothing window.
-    if smooth_weights == 'uniform':
+    # Compute the weights across the filter window.
+    if filter_weights == 'uniform':
         weights = np.ones_like(dt)
 
-    if smooth_weights == 'tricube':
-        radius = smooth_window / 2
+    if filter_weights == 'tricube':
+        radius = filter_window / 2
         weights = np.where(np.abs(dt) < radius, (1 - np.abs(dt / radius) ** 3) ** 3, 0)
 
     # Normalise the weights.
@@ -471,8 +471,8 @@ def _lstsq_templates(mid_times: np.ndarray,
                      ld_pars: ArrayLike,
                      exp_time: float,
                      exp_cadence: float,
-                     smooth_window: Optional[float],
-                     smooth_weights: utils.SmoothWeights
+                     filter_window: Optional[float],
+                     filter_weights: utils.FilterWeights
                      ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """ Compute the transit shapes needed to generate the least-squares templates.
 
@@ -496,18 +496,18 @@ def _lstsq_templates(mid_times: np.ndarray,
         The exposure time of the observations in days.
     exp_cadence: float
         The exposure cadence of the observations in days.
-    smooth_window: float or None
-        The smoothing window to use when generating WLS templates, should match
+    filter_window: float or None
+        The filter window to use when generating WLS templates, should match
         whatever filter was applied to the data.
-    smooth_weights: str
-        The weights to apply across the smoothing window when generating WLS
+    filter_weights: str
+        The weights to apply across the filter window when generating WLS
         templates, should match whatever filter was applied to the data.
 
     """
 
     # Generate the time and weights arrays for WLS.
-    if smooth_window is not None:
-        result = _warped_lstsq_init(mid_times, exp_cadence, smooth_window, smooth_weights)
+    if filter_window is not None:
+        result = _warped_lstsq_init(mid_times, exp_cadence, filter_window, filter_weights)
         wls_times, wls_weights = result
 
         # Need 1D time array for batman.
@@ -554,7 +554,7 @@ def _lstsq_templates(mid_times: np.ndarray,
         fac = result[5]  # Save fac for WLS templates.
         tls_template[row_idx] = result[0]
 
-        if smooth_window is not None:
+        if filter_window is not None:
             # Evaluate the transit model.
             result = analytic_transit_model(wls_times,
                                             transit_params,
@@ -582,8 +582,8 @@ def get_lstsq_templates(periods: np.ndarray,
                         ref_depth: float = 5000,
                         ref_impact: float = 0.,
                         search_mode: utils.SearchMode = 'TLS',
-                        smooth_window: Optional[float] = None,
-                        smooth_weights: utils.SmoothWeights = 'uniform'
+                        filter_window: Optional[float] = None,
+                        filter_weights: utils.FilterWeights = 'uniform'
                         ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """ Get the least-squares transit templates for the chosen search mode.
 
@@ -612,11 +612,11 @@ def get_lstsq_templates(periods: np.ndarray,
     search_mode: str
         The type of transit templates to use, can be 'BLS', 'TLS' or 'WLS'
         (default: 'TLS').
-    smooth_window: float or None
-        The smoothing window to use when search_mode = 'WLS', should match any
+    filter_window: float or None
+        The filter window to use when search_mode = 'WLS', should match any
         whatever filter was applied to the data (default: None).
-    smooth_weights: str
-        The weights to apply across the smoothing window when search_mode = 'WLS',
+    filter_weights: str
+        The weights to apply across the filter window when search_mode = 'WLS',
         should match whatever filter was applied to the data and can be 'uniform'
         or 'tricube' (default: 'uniform').
 
@@ -636,7 +636,7 @@ def get_lstsq_templates(periods: np.ndarray,
 
     utils._verify_observation_params(exp_time, exp_cadence)
     ld_pars = utils._verify_ld_params(ld_type, ld_pars)
-    smooth_window = utils._verify_lstsq_params(search_mode, smooth_window, smooth_weights, 'TLS')
+    filter_window = utils._verify_lstsq_params(search_mode, filter_window, filter_weights, 'TLS')
 
     # Convert depth from ppm to fraction.
     ref_depth = 1e-6 * ref_depth
@@ -648,15 +648,15 @@ def get_lstsq_templates(periods: np.ndarray,
 
     # Check the baseline.
     baseline = min_period - max_duration - exp_time
-    if search_mode == 'WLS' and periods.size > 1 and baseline < smooth_window:
+    if search_mode == 'WLS' and periods.size > 1 and baseline < filter_window:
         LOGWARNING("Cannot make WLS templates for this period range, defaulting to TLS templates.")
         search_mode: utils.SearchMode = 'TLS'
 
-    # Compute the duration of the signal, accounting for exp_time and smooth_window.
+    # Compute the duration of the signal, accounting for exp_time and filter_window.
     if search_mode in ['BLS', 'TLS']:
         delta_time = max_duration + exp_time
     else:
-        delta_time = max_duration + exp_time + smooth_window
+        delta_time = max_duration + exp_time + filter_window
 
     if periods.size == 1:
         delta_time = np.minimum(delta_time, max_period)
@@ -688,8 +688,8 @@ def get_lstsq_templates(periods: np.ndarray,
                               ld_pars,
                               exp_time,
                               exp_cadence,
-                              smooth_window,
-                              smooth_weights)
+                              filter_window,
+                              filter_weights)
     bls_template, tls_template, wls_template = result
 
     # Choose the final template based on the search mode.

--- a/src/umbra/search.py
+++ b/src/umbra/search.py
@@ -79,7 +79,7 @@ def make_period_groups(period_grid: np.ndarray,
                        duration_grid: np.ndarray,
                        duration_lims: grid.DurationLimits,
                        exp_time: float,
-                       frac_duration_step: float = 1.05,
+                       frac_duration_step: float = 1.095,
                        period_group_sampling: int = 3,
                        epoch_sampling: int = 20,
                        min_epoch_step: float = 1 / utils.MIN_IN_DAY,
@@ -103,7 +103,7 @@ def make_period_groups(period_grid: np.ndarray,
         integrations.
     frac_duration_step: float
         The ratio between consecutive durations in the grid. Equivalent to a
-        grid with log-steps of log10(frac_duration_step) (default: 1.05).
+        grid with log-steps of log10(frac_duration_step) (default: 1.095).
     period_group_sampling: int
         The number of duration steps between the longest duration at the start
         of subsequent period groups.
@@ -648,7 +648,7 @@ def _transit_search(time: np.ndarray,
                     max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                     circular_orbits: bool = True,
                     frac_eccentricity: float = 0.90,
-                    frac_duration_step: float = 1.05,
+                    frac_duration_step: float = 1.095,
                     period_group_sampling: int = 3,
                     normalisation: utils.Normalisation = 'umbra',
                     ld_type: utils.LDType = 'linear',
@@ -711,7 +711,7 @@ def _transit_search(time: np.ndarray,
         False (default: 0.90).
     frac_duration_step: float
         The ratio between consecutive durations in the grid. Equivalent to a
-        grid with log-steps of log10(frac_duration_step) (default: 1.05).
+        grid with log-steps of log10(frac_duration_step) (default: 1.095).
     period_group_sampling: int
         The number of duration steps between the longest duration at the start
         of subsequent period groups.
@@ -1039,7 +1039,7 @@ class TransitSearch:
                  max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                  circular_orbits: bool = True,
                  frac_eccentricity: float = 0.90,
-                 frac_duration_step: float = 1.05,
+                 frac_duration_step: float = 1.095,
                  period_group_sampling: int = 3,
                  normalisation: utils.Normalisation = 'umbra',
                  num_processes: Optional[int] = None,

--- a/src/umbra/search.py
+++ b/src/umbra/search.py
@@ -84,7 +84,7 @@ def make_period_groups(period_grid: np.ndarray,
                        epoch_sampling: int = 20,
                        min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                        max_epoch_step: float = 5 / utils.MIN_IN_DAY,
-                       smooth_window: Optional[float] = None
+                       filter_window: Optional[float] = None
                        ) -> list[PeriodGroup]:
     """ Split the full period range into groups to avoid cases
         where the max duration exceeds the min period.
@@ -114,9 +114,9 @@ def make_period_groups(period_grid: np.ndarray,
         The smallest acceptable epoch step in days (default: 1 minute).
     max_epoch_step: float
         The largest acceptable epoch step in days (default: 5 minutes).
-    smooth_window: float, optional
-        If given the second groups first period is choses so that it contains no
-        cases where the smooth window contain multiple transits.
+    filter_window: float, optional
+        If given the second period groups shortest period is choses so that it
+        contains no cases where the filter window contain multiple transits.
 
     Returns
     -------
@@ -133,18 +133,18 @@ def make_period_groups(period_grid: np.ndarray,
         msg = f"Longest duty cycle > {utils.MAX_DUTY_CYCLE:.2f}, reducing period_group_sampling is recommended."
         LOGWARNING(msg)
 
-    # Identify the shortest period which is guaranteed to have only 1 transit in the smooth window.
+    # Identify the shortest period which is guaranteed to have only 1 transit in the filter window.
     icut = -1
-    if smooth_window is not None:
+    if filter_window is not None:
 
         # Guaranteed baseline if this period is the start of a period group.
         baseline = period_grid - excess_duration_ratio * duration_lims.long - exp_time
 
-        # Index of shortest period with baseline > smooth_window.
-        icut = np.searchsorted(baseline, smooth_window, side='right')
+        # Index of shortest period with baseline > filter_window.
+        icut = np.searchsorted(baseline, filter_window, side='right')
 
         if utils.DEBUG:
-            diagnostics.plot_oot_baseline(period_grid, baseline, smooth_window)
+            diagnostics.plot_oot_baseline(period_grid, baseline, filter_window)
 
     imin = 0
     intervals = []
@@ -156,7 +156,7 @@ def make_period_groups(period_grid: np.ndarray,
 
         # Create a period group break where WLS becomes fast.
         if imax == icut:
-            LOGDEBUG(f"Adding split for smooth window.")
+            LOGDEBUG(f"Adding split for filter window.")
             intervals.append((imin, imax))
             imin = imax
             continue
@@ -210,8 +210,8 @@ def _search_period(period: np.ndarray,
                    templates: Optional[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]],
                    min_points: np.ndarray,
                    normalisation: utils.Normalisation,
-                   smooth_window: float,
-                   smooth_weights: utils.SmoothWeights,
+                   filter_window: float,
+                   filter_weights: utils.FilterWeights,
                    exp_time: float,
                    exp_cadence: float,
                    ld_type: utils.LDType,
@@ -231,8 +231,8 @@ def _search_period(period: np.ndarray,
                                                ld_type=ld_type,
                                                ld_pars=ld_pars,
                                                search_mode='WLS',
-                                               smooth_window=smooth_window,
-                                               smooth_weights=smooth_weights)
+                                               filter_window=filter_window,
+                                               filter_weights=filter_weights)
 
     # Unpack the transit templates.
     template_edges = templates[0]
@@ -655,8 +655,8 @@ def _transit_search(time: np.ndarray,
                     ld_pars: ArrayLike = (0.6,),
                     search_mode: utils.SearchMode = 'TLS',
                     short_periods: utils.ShortPeriods = 'skip',
-                    smooth_window: Optional[float] = None,
-                    smooth_weights: utils.SmoothWeights = 'uniform',
+                    filter_window: Optional[float] = None,
+                    filter_weights: utils.FilterWeights = 'uniform',
                     num_processes: Optional[int] = None,
                     ) -> tuple[dict, dict, dict]:
     """ Perform a transit search on the provided data.
@@ -729,13 +729,13 @@ def _transit_search(time: np.ndarray,
     short_periods: str
         How to treat short periods when search_mode = 'WLS', can be 'skip',
         'TLS' or 'WLS' (default: 'skip').
-    smooth_window: float or None
-        The smoothing window to use when search_mode = 'WLS', should match any
-        whatever filter was applied to the data (default: None).
-    smooth_weights: str
-        The weights to apply across the smoothing window when search_mode = 'WLS',
-        should match whatever filter was applied to the data and can be 'uniform'
-        or 'tricube' (default: 'uniform').
+    filter_window: float or None
+        The filter window to use when search_mode = 'WLS', should match the
+        lightcurve filter that was applied to the data (default: None).
+    filter_weights: str
+        The weights to apply across the filter window when search_mode = 'WLS',
+        should match the lightcurve filter that was applied to the data and can
+        be 'uniform' or 'tricube' (default: 'uniform').
     num_processes: int or None
         The number of CPUs to use when multi-processing (default: None).
 
@@ -763,7 +763,7 @@ def _transit_search(time: np.ndarray,
     utils._verify_period_group_sampling(period_group_sampling)
     utils._verify_normalisation(normalisation)
     ld_pars = utils._verify_ld_params(ld_type, ld_pars)
-    smooth_window = utils._verify_lstsq_params(search_mode, smooth_window, smooth_weights, short_periods)
+    filter_window = utils._verify_lstsq_params(search_mode, filter_window, filter_weights, short_periods)
     num_processes = utils._verify_num_processes(num_processes)
 
     # Pre-compute some arrays from the lightcurves.
@@ -825,7 +825,7 @@ def _transit_search(time: np.ndarray,
                                        epoch_sampling=epoch_sampling,
                                        min_epoch_step=min_epoch_step,
                                        max_epoch_step=max_epoch_step,
-                                       smooth_window=smooth_window)
+                                       filter_window=filter_window)
 
     # Set up variables for the output.
     nrows = period_grid.size
@@ -867,7 +867,7 @@ def _transit_search(time: np.ndarray,
 
         is_short_period = False
         baseline = np.amin(period_group) - np.amax(duration_group) - exp_time
-        if search_mode == 'WLS' and baseline < smooth_window:
+        if search_mode == 'WLS' and baseline < filter_window:
             group.search_mode = short_periods
             if short_periods == 'skip':
                 LOGDEBUG("  Skipping short periods in WLS search.")
@@ -894,8 +894,8 @@ def _transit_search(time: np.ndarray,
                                                    ld_type=ld_type,
                                                    ld_pars=ld_pars,
                                                    search_mode=group.search_mode,
-                                                   smooth_window=smooth_window,
-                                                   smooth_weights=smooth_weights)
+                                                   filter_window=filter_window,
+                                                   filter_weights=filter_weights)
         else:
             templates = None
 
@@ -910,8 +910,8 @@ def _transit_search(time: np.ndarray,
         kwargs['templates'] = templates
         kwargs['min_points'] = 0.5*duration_group/exp_cadence
         kwargs['normalisation'] = normalisation
-        kwargs['smooth_window'] = smooth_window
-        kwargs['smooth_weights'] = smooth_weights
+        kwargs['filter_window'] = filter_window
+        kwargs['filter_weights'] = filter_weights
         kwargs['exp_time'] = exp_time
         kwargs['exp_cadence'] = exp_cadence
         kwargs['ld_type'] = ld_type
@@ -991,7 +991,7 @@ def _transit_search(time: np.ndarray,
         periodogram = search_result_circ['periodogram']
         transit_model = search_result_circ['transit_model']
 
-        diagnostics.plot_quick_look(time, flux, periodogram, transit_model, smooth_window)
+        diagnostics.plot_quick_look(time, flux, periodogram, transit_model, filter_window)
         diagnostics.plot_1d_periodogram(periodogram)
 
     # Generate the final peridogram for the full duration range.
@@ -1020,7 +1020,7 @@ def _transit_search(time: np.ndarray,
         periodogram = search_result_full['periodogram']
         transit_model = search_result_full['transit_model']
 
-        diagnostics.plot_quick_look(time, flux, periodogram, transit_model, smooth_window)
+        diagnostics.plot_quick_look(time, flux, periodogram, transit_model, filter_window)
         diagnostics.plot_1d_periodogram(periodogram)
 
     return search_header, search_result_circ, search_result_full
@@ -1254,8 +1254,8 @@ class TransitSearch:
                      max_stellar_mass: float,
                      ld_type: utils.LDType,
                      ld_pars: ArrayLike,
-                     smooth_window: float,
-                     smooth_weights: utils.SmoothWeights = 'uniform',
+                     filter_window: float,
+                     filter_weights: utils.FilterWeights = 'uniform',
                      short_periods: utils.ShortPeriods = 'skip',
                      output_file: Optional[str] = None
                      ):
@@ -1291,8 +1291,8 @@ class TransitSearch:
             ld_pars=ld_pars,
             search_mode="WLS",
             short_periods=short_periods,
-            smooth_window=smooth_window,
-            smooth_weights=smooth_weights,
+            filter_window=filter_window,
+            filter_weights=filter_weights,
             num_processes=self.num_processes)
 
         target_config = dict()
@@ -1305,8 +1305,8 @@ class TransitSearch:
         target_config['max_stellar_mass'] = max_stellar_mass
         target_config['ld_type'] = ld_type
         target_config['ld_pars'] = np.asarray(ld_pars)
-        target_config['smooth_window'] = smooth_window
-        target_config['smooth_weights'] = smooth_weights
+        target_config['filter_window'] = filter_window
+        target_config['filter_weights'] = filter_weights
         target_config['short_periods'] = short_periods
 
         full_result = self._full_search_result(target_config,

--- a/src/umbra/search.py
+++ b/src/umbra/search.py
@@ -647,7 +647,7 @@ def _transit_search(time: np.ndarray,
                     min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                     max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                     circular_orbits: bool = True,
-                    frac_eccentricity: float = 0.95,
+                    frac_eccentricity: float = 0.90,
                     frac_duration_step: float = 1.05,
                     period_group_sampling: int = 3,
                     normalisation: utils.Normalisation = 'umbra',
@@ -708,7 +708,7 @@ def _transit_search(time: np.ndarray,
     frac_eccentricity: float
         The fraction of the maximum stable eccentricity to consider, slightly
         limits the size of the duration space searched when circular_orbits =
-        False (default: 0.95).
+        False (default: 0.90).
     frac_duration_step: float
         The ratio between consecutive durations in the grid. Equivalent to a
         grid with log-steps of log10(frac_duration_step) (default: 1.05).
@@ -1038,7 +1038,7 @@ class TransitSearch:
                  min_epoch_step: float = 1 / utils.MIN_IN_DAY,
                  max_epoch_step: float = 5 / utils.MIN_IN_DAY,
                  circular_orbits: bool = True,
-                 frac_eccentricity: float = 0.95,
+                 frac_eccentricity: float = 0.90,
                  frac_duration_step: float = 1.05,
                  period_group_sampling: int = 3,
                  normalisation: utils.Normalisation = 'umbra',

--- a/src/umbra/utils.py
+++ b/src/umbra/utils.py
@@ -48,7 +48,7 @@ LDType = Literal["uniform", "linear", "quadratic", "square-root", "logarithmic",
 BinMethod = Literal["points", "window"]
 SearchMode = Literal["BLS", "TLS", "WLS"]
 ShortPeriods = Literal["skip", "TLS", "WLS"]
-SmoothWeights = Literal["uniform", "tricube"]
+FilterWeights = Literal["uniform", "tricube"]
 Normalisation = Literal["simple", "umbra"]
 
 
@@ -260,8 +260,8 @@ def _verify_frac_duration_step(frac_duration_step: float):
 
 
 def _verify_lstsq_params(search_mode: SearchMode,
-                         smooth_window: Optional[float],
-                         smooth_weights: SmoothWeights,
+                         filter_window: Optional[float],
+                         filter_weights: FilterWeights,
                          short_periods: ShortPeriods
                          ) -> Optional[float]:
 
@@ -271,29 +271,29 @@ def _verify_lstsq_params(search_mode: SearchMode,
 
     if search_mode in ["BLS", "TLS"]:
 
-        if smooth_window is not None:
-            LOGWARNING(f"Performing {search_mode} search, setting smooth_window to None.")
-            smooth_window = None
+        if filter_window is not None:
+            LOGWARNING(f"Performing {search_mode} search, setting filter_window to None.")
+            filter_window = None
 
-        return smooth_window
+        return filter_window
 
-    if smooth_window is None:
-        msg = f"Parameter smooth_window cannot be None for 'WLS' search."
+    if filter_window is None:
+        msg = f"Parameter filter_window cannot be None for 'WLS' search."
         raise ValueError(msg)
 
-    if not (smooth_window > 0):
-        msg = f"Parameter smooth_window must be greater than zero."
+    if not (filter_window > 0):
+        msg = f"Parameter filter_window must be greater than zero."
         raise ValueError(msg)
 
-    if smooth_weights not in get_args(SmoothWeights):
-        msg = f"Invalid value '{smooth_weights}' for parameter smooth_weights."
+    if filter_weights not in get_args(FilterWeights):
+        msg = f"Invalid value '{filter_weights}' for parameter filter_weights."
         raise ValueError(msg)
 
     if short_periods not in get_args(ShortPeriods):
         msg = f"Invalid value '{short_periods}' for parameter short_periods."
         raise ValueError(msg)
 
-    return smooth_window
+    return filter_window
 
 
 def _verify_period_group_sampling(period_group_sampling: int):


### PR DESCRIPTION
Changed default duration grid spacing from 1.05 to 1.095 to match CETRA.
Changed default maximum eccentricity fraction from 0.95 to 0.90 to save computation time.
Renamed smooth_window and smooth_weights to filter_window and filter_weights for clarity.
Associated edits to documentation etc.

@saigrain Please approve the PR, but do not merge the branch.